### PR TITLE
feat: Repair install problem in debootstrap+chroot environment

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -25,7 +25,6 @@ endif
 override_dh_auto_install:
 	$(MAKE) install PREFIX=debian/anacron MANDIR=debian/anacron/usr/share/man
 	install -D -m 644 debian/anacrontab debian/anacron/etc/anacrontab
-	install -D -m 644 debian/anacron.timer debian/anacron/lib/systemd/system/anacron.timer
 
 override_dh_installcron:
 	dh_installcron


### PR DESCRIPTION
If you install `anacron` in deepin25 chroot rootf, you will get this error and can't install other packages
```bash
dpkg: 处理归档 /var/cache/apt/archives/anacron_2.3-deepin1_loong64.deb (--unpack)时出错：
 无法打开 /usr/lib/systemd/system/anacron.timer.dpkg-new: 没有那个文件或目录
在处理时有错误发生：
 /var/cache/apt/archives/anacron_2.3-deepin1_loong64.deb
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

Testing Environment:
Arch: loong64
System: deepin25 (From debootstrap and use chroot)